### PR TITLE
Replace devterm-its with bkspartners

### DIFF
--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -13,13 +13,13 @@ dependencies:
   path: '>=1.0.0 <=2.0.0'
   openapi_generator_annotations:
     git:
-      url: https://github.com/devterm-its/openapi-generator-dart.git
+      url: https://github.com/bkspartners/openapi-generator-dart.git
       ref: master
       path: openapi-generator-annotations
   analyzer: '>=2.0.0 <7.0.0'
   openapi_generator_cli:
     git:
-      url: https://github.com/devterm-its/openapi-generator-dart.git
+      url: https://github.com/bkspartners/openapi-generator-dart.git
       ref: master
       path: openapi-generator-cli
   yaml: ^3.1.2


### PR DESCRIPTION
We have recently moved from the devterm-its organisation to bkspartners. As the project links to repositories inside the organisation, the urls have to be adjusted.